### PR TITLE
BUGFIX: fix error 'list index out of range'

### DIFF
--- a/mech/utils.py
+++ b/mech/utils.py
@@ -111,7 +111,8 @@ def parse_vmx(path):
     with open(path) as fp:
         for line in fp:
             line = line.strip().split('=', 1)
-            vmx[line[0].rstrip()] = line[1].lstrip()
+            if len(line) > 1:
+                vmx[line[0].rstrip()] = line[1].lstrip()
     return vmx
 
 


### PR DESCRIPTION
Bugfix for #32 (mech up: list index out of range)

The Bug happens because the .vmx file contains empty lines

Testsystem: Windows 10; Pyhton 2.7.14; VMWare Workstation 12

Box: bento/ubuntu-14.04 
Code Example (ubuntu-14.04-amd64.vmx)
```
.encoding = "UTF-8"

bios.bootorder = "hdd,CDROM"
```
