### PR TITLE
This should fix #37

### DIFF
--- a/mech/utils.py
+++ b/mech/utils.py
@@ -321,7 +321,7 @@ def tar_cmd(*args, **kwargs):
         return None
     stdoutdata, stderrdata = map(b2s, proc.communicate())
     tar = ['tar']
-    if kwargs.get('wildcards') and re.search(r'\b--wildcards\b', stdoutdata):
+    if kwargs.get('wildcards') and re.search(r'--wildcards', stdoutdata):
         tar.append('--wildcards')
     if kwargs.get('fast_read') and sys.platform.startswith('darwin'):
         tar.append('--fast-read')


### PR DESCRIPTION
Seems there is an issue with the regex so --wildcards parameter never is passed to the tar command.

````
-> if kwargs.get('wildcards') and re.search(r'\b--wildcards\b', stdoutdata):
(Pdb) p re.search(r'\b--wildcards\b', stdoutdata)
None
(Pdb) p re.search(r'--wildcards', stdoutdata)
<re.Match object; span=(3148, 3159), match='--wildcards'>
(Pdb)
```