### PR TITLE
add command line option to disable shared folder

### DIFF
--- a/mech/mech.py
+++ b/mech/mech.py
@@ -585,6 +585,7 @@ class Mech(MechCommand):
 
         Options:
                 --gui                        Start GUI
+                --disable-shared-folder      Do not share folder with VM
                 --provision                  Enable provisioning
                 --insecure                   Do not validate SSL certificates
                 --cacert FILE                CA certificate for SSL download
@@ -596,6 +597,7 @@ class Mech(MechCommand):
             -h, --help                       Print this help
         """
         gui = arguments['--gui']
+        disable_shared_folder = not arguments['--disable-shared-folder']
         save = not arguments['--no-cache']
         requests_kwargs = utils.get_requests_kwargs(arguments)
 
@@ -616,8 +618,9 @@ class Mech(MechCommand):
             lookup = self.get("enable_ip_lookup", False)
             ip = vmrun.getGuestIPAddress(lookup=lookup)
             puts_err(colored.blue("Sharing current folder..."))
-            vmrun.enableSharedFolders()
-            vmrun.addSharedFolder('mech', os.getcwd(), quiet=True)
+            if not disable_shared_folder:
+                vmrun.enableSharedFolders()
+                vmrun.addSharedFolder('mech', os.getcwd(), quiet=True)
             if ip:
                 if started:
                     puts_err(colored.green("VM started on {}".format(ip)))


### PR DESCRIPTION
Resolves #65 

Unfortunately, it does not speed up the start.

```
$ time mech up
Loading metadata for box 'bento/centos-8' (201912.04.0)
Extracting box 'bento/centos-8'...
Added network interface to vmx file
Bringing machine up...
Getting IP address...
Sharing current folder...
VM started on 192.168.2.219

real	0m54.385s
user	0m4.161s
sys	0m0.804s

$ mech destroy -f
Deleting...

$ time mech up --disable-shared-folder
Loading metadata for box 'bento/centos-8' (201912.04.0)
Extracting box 'bento/centos-8'...
Added network interface to vmx file
Bringing machine up...
Getting IP address...
Sharing current folder...
VM started on 192.168.2.219

real	0m54.791s
user	0m4.306s
sys	0m0.827s
$
```