### PR TITLE
Use the python os.path.sep for path seperators

### DIFF
--- a/mech/mech.py
+++ b/mech/mech.py
@@ -255,7 +255,7 @@ class MechBox(MechCommand):
         for root, dirnames, filenames in os.walk(path):
             for filename in fnmatch.filter(filenames, '*.box'):
                 directory = os.path.dirname(os.path.join(root, filename))[len(path) + 1:]
-                account, box, version = (directory.split('/', 2) + ['', ''])[:3]
+                account, box, version = (directory.split(os.path.sep, 2) + ['', ''])[:3]
                 print("{}\t{}".format(
                     "{}/{}".format(account, box).rjust(35),
                     version.rjust(12),

--- a/mech/utils.py
+++ b/mech/utils.py
@@ -273,7 +273,7 @@ def build_mechfile(descriptor, name=None, version=None, requests_kwargs={}):
             return mechfile
     else:
         try:
-            account, box, v = (descriptor.split('/', 2) + ['', ''])[:3]
+            account, box, v = (descriptor.split(os.path.sep, 2) + ['', ''])[:3]
             if not account or not box:
                 puts_err(colored.red("Provided box name is not valid"))
             if v:


### PR DESCRIPTION
This change uses the os.path.sep python variable for manipulating paths in mech.  This allows mech to properly split out the box name/version etc under windows.